### PR TITLE
[ADD] use_global_static_ip var to allow our ci tests to not depend on…

### DIFF
--- a/k8s/jenkins/chart/jenkins/templates/manifests.yaml
+++ b/k8s/jenkins/chart/jenkins/templates/manifests.yaml
@@ -125,7 +125,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-jenkins-ui
-{{ if .Values.gcp_load_balancer.global_static_ip }}
+{{ if .Values.gcp_load_balancer.use_global_static_ip }}
   annotations:
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.gcp_load_balancer.global_static_ip }}
 {{ end }}

--- a/k8s/jenkins/chart/jenkins/values.yaml
+++ b/k8s/jenkins/chart/jenkins/values.yaml
@@ -8,7 +8,8 @@ jenkins:
   runSetupWizard: false
   plugins: null
 gcp_load_balancer:
-  global_static_ip: null
+  use_global_static_ip: null
+  global_static_ip_name: null
 tls:
   base64EncodedPrivateKey: null
   base64EncodedCertificate: null


### PR DESCRIPTION
… an existing GCP static ip

<!--- /gcbrun -->
