### PR TITLE
[IMP] allow ssl_policies for GKE 1.17.6+

### DIFF
--- a/k8s/jenkins/chart/jenkins/templates/manifests.yaml
+++ b/k8s/jenkins/chart/jenkins/templates/manifests.yaml
@@ -135,6 +135,9 @@ metadata:
   {{- if .Values.gcp.use_global_static_ip }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.gcp.global_static_ip_name }}
   {{- end }}
+  {{- if .Values.gcp.use_ssl_policy }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.gcp.ssl_policy_name }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     app.kubernetes.io/component: jenkins-master

--- a/k8s/jenkins/chart/jenkins/values.yaml
+++ b/k8s/jenkins/chart/jenkins/values.yaml
@@ -13,6 +13,8 @@ gcp:
   global_static_ip_name: null
   use_nodepool: false
   nodepool_name: null
+  use_ssl_policy: false
+  ssl_policy_name: null
 tls:
   base64EncodedPrivateKey: null
   base64EncodedCertificate: null


### PR DESCRIPTION
Groundwork for letting SSL policies work for Jenkins when we get to them.

Can follow [this issue](https://github.com/kubernetes/ingress-gce/issues/246#issuecomment-656369807) for updates.

This can be enabled in the Rapid GKE Channel, but not in Regular yet.
