### PR TITLE
Update manifests.yaml

### DIFF
--- a/k8s/jenkins/chart/jenkins/templates/manifests.yaml
+++ b/k8s/jenkins/chart/jenkins/templates/manifests.yaml
@@ -50,6 +50,12 @@ spec:
         - name: {{ .Release.Name }}-jenkins-casc-yaml
           mountPath: /tmp/jenkins.yaml
           subPath: jenkins.yaml
+        livenessProbe:
+          httpGet:
+            path: /login
+            port: 8080
+          periodSeconds: 10
+          initialDelaySeconds: 30
         readinessProbe:
           httpGet:
             path: /login


### PR DESCRIPTION
<!--- /gcbrun -->
I've ended up down this road because the latest deployment of jenkins is causing the ingress controller health checks to fail. It is failing against the ingress object, port 80, root path /, so by setting the liveness probe here we are hoping the ingress is able to pick up that information to resolve the failing health checks.

dont know how this ever worked.
