### PR TITLE
[ADD] http->https redirects

### DIFF
--- a/k8s/jenkins/chart/jenkins/templates/manifests.yaml
+++ b/k8s/jenkins/chart/jenkins/templates/manifests.yaml
@@ -151,6 +151,9 @@ metadata:
   name: {{ .Values.gcp.ssl_policy_name }}
 spec:
   sslPolicy: {{ .Values.gcp.ssl_policy_name }}
+  redirectToHttps:
+    enabled: true
+    responseCodeName: PERMANENT_REDIRECT
 {{ end }}
 ---
 apiVersion: cloud.google.com/v1
@@ -170,7 +173,7 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-jenkins-ui
   annotations:
-    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.allow-http: "true"
   {{- if .Values.gcp.use_global_static_ip }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.gcp.global_static_ip_name }}
   {{- end }}


### PR DESCRIPTION
https://github.com/um-h-devops/click-to-deploy/pull/new/https_redirect

"To support HTTP to HTTPS redirection, an Ingress must be configured to serve both HTTP and HTTPS traffic. If either HTTP or HTTPS is disabled, redirection will not work."
